### PR TITLE
Small improvements

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -7,15 +7,15 @@
     "reference": "v0.10.0",
     "license": "MIT",
     "require": {
-	"php": ">=5.3.0"
+        "php": ">=5.3.0"
     },
     "require-dev": {
-	"php": ">=5.3.0",
-	"phpunit/phpunit": "3.7.*"
+        "php": ">=5.3.0",
+        "phpunit/phpunit": "3.7.*"
     },
     "autoload": {
-	"classmap": [
-		"source/"
-	]
+        "classmap": [
+            "source/"
+        ]
     }
 }

--- a/source/core/Client.php
+++ b/source/core/Client.php
@@ -258,18 +258,7 @@ final class Client {
       if ($users)
         return $this->endpoint . "/v1/users/" . $this->uid . "/" . $url;
 
-      return $this->endpoint . "/v1/". $url; 
-    }
-
-   /**
-    * Handle the headers given
-    * successful response
-    *
-    * @param headers -> string ":" seperated headers
-    */
-    private function headerHandler($headers)
-    {
-      return $headers;
+      return $this->endpoint . "/v1/". $url;
     }
 
    /**
@@ -350,9 +339,13 @@ final class Client {
           $headers[$h[0]] = trim(str_replace("\r\n", "", str_replace("\n", "", $h[1]))); 
       }
 
+      /* HTTP headers are case-insensitive so let's convert them to lowercase */
+      /* for internal consistency when working with them */
+      $headers = array_change_key_case($headers, CASE_LOWER);
+
       /* add support for header only responses where information is only found in "location" */
       /* in some cases we need the raw content (Media Files) */
-      if (isset($headers['Content-Type']) && in_array($headers['Content-Type'], self::$media_formats)) {
+      if (isset($headers['content-type']) && in_array($headers['content-type'], self::$media_formats)) {
         return $noformat;
       }
 

--- a/source/utils/Base.php
+++ b/source/utils/Base.php
@@ -53,6 +53,8 @@ class BaseUtilities {
        */
       public static function find($headers, $term)
       {
+        //Internal headers are always lowercase
+        $term = strtolower($term);
         if (!(isset($headers[$term]))) {
           throw new \CatapultApiException("No header found as $term:");
         }

--- a/source/utils/Locator.php
+++ b/source/utils/Locator.php
@@ -26,16 +26,7 @@ class Locator extends BaseUtilities {
     */
     public static function find($headers,$id=true)
     {
-      //Fix for incompatibility with php >= 7.2 "Location" must be "location" for php >= 7.2
-      $header = null;
-      $phpver = explode('.', phpversion());
-
-      if ($phpver[0] >= 7 && $phpver[1] >= 2) {
-        $header = parent::find($headers, "location");
-      }
-      else {
-        $header = parent::find($headers, "Location");
-      }
+      $header = parent::find($headers, "Location");
 
       if ($id) {
         $match = array();
@@ -43,6 +34,6 @@ class Locator extends BaseUtilities {
         return str_replace("\r", "", str_replace("\n", "", $pieces[sizeof($pieces) - 1]));
       }
 
-    return $header;
+      return $header;
     }	
 }


### PR DESCRIPTION
Improve HTTP headers by:

- Converting headers to lowercase for easier handling
- Avoid extraneous PHP version checks
- Remove extraneous header function from Client class

This reworks [this previous fix](https://github.com/Bandwidth/php-bandwidth/commit/5e1cd10dbab408193604a2ed19e20a7aafd3f810) in a more foolproof way.

Also improve composer.json to have consistent spacing.